### PR TITLE
fix: prevent Chart constructor from mutating shared default_settings object

### DIFF
--- a/project/src/chart.ts
+++ b/project/src/chart.ts
@@ -23,7 +23,7 @@ class Chart {
   radius: number
   settings: Settings
   constructor (elementId: string, width: number, height: number, settings?: Partial<Settings>) {
-    const chartSettings = default_settings
+    const chartSettings = { ...default_settings }
     if (settings != null) {
       Object.assign(chartSettings, settings)
       if (!('COLORS_SIGNS' in settings)) chartSettings.COLORS_SIGNS = [default_settings.COLOR_ARIES, default_settings.COLOR_TAURUS, default_settings.COLOR_GEMINI, default_settings.COLOR_CANCER, default_settings.COLOR_LEO, default_settings.COLOR_VIRGO, default_settings.COLOR_LIBRA, default_settings.COLOR_SCORPIO, default_settings.COLOR_SAGITTARIUS, default_settings.COLOR_CAPRICORN, default_settings.COLOR_AQUARIUS, default_settings.COLOR_PISCES]


### PR DESCRIPTION
Closes #14

## Status
**SHIP** — Iteration 1

## Summary
- **Bug**: The `Chart` constructor in `project/src/chart.ts` assigned `default_settings` by reference (`const chartSettings = default_settings`), then mutated it via `Object.assign(chartSettings, settings)`. This caused every Chart instance with custom settings to permanently alter the shared module-level `default_settings` object, leaking settings between instances.
- **Fix**: Changed line 26 to use a spread copy (`const chartSettings = { ...default_settings }`), so each Chart instance gets its own independent settings object.
- **Files modified**: `project/src/chart.ts` (1 line changed)
- **Tests**: All 425 tests pass across 17 test suites.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_