### PR TITLE
fix: correct modulo formula in getHouseNumber cusp index wrapping

### DIFF
--- a/project/src/zodiac.ts
+++ b/project/src/zodiac.ts
@@ -78,14 +78,14 @@ class Zodiac {
     const angle = point % radiansToDegree(2 * Math.PI)
 
     for (let i = 0, ln = this.cusps.length; i < ln; i++) {
-      if (angle >= this.cusps[i] && angle < this.cusps[(i % (ln - 1)) + 1]) {
+      if (angle >= this.cusps[i] && angle < this.cusps[(i + 1) % ln]) {
         return i + 1
       }
     }
 
     // cusp passes over zero
     for (let i = 0, ln = this.cusps.length; i < ln; i++) {
-      if (this.cusps[i] > this.cusps[(i % (ln - 1)) + 1]) {
+      if (this.cusps[i] > this.cusps[(i + 1) % ln]) {
         return i + 1
       }
     }


### PR DESCRIPTION
Closes #16

## Status
✅ SHIP — Iteration 1

## Summary
- Fixed the modulo formula bug in `getHouseNumber` method in `project/src/zodiac.ts`
- Replaced `(i % (ln - 1)) + 1` with `(i + 1) % ln` on lines 81 and 88
- The old formula incorrectly wrapped cusp index 11 to 1 instead of 0, causing the 12th house boundary check to compare against `cusps[1]` instead of `cusps[0]`

## Test Results
All 425 tests pass across 17 test suites.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_