### PR TITLE
fix: add main axis stroke differentiation in transit drawCusps

### DIFF
--- a/project/src/transit.ts
+++ b/project/src/transit.ts
@@ -173,7 +173,6 @@ class Transit {
       return
     }
 
-    let bottomPosition
     const universe = this.universe
     const wrapper = getEmptyWrapper(universe, this.paper._paperElementId + '-' + this.settings.ID_TRANSIT + '-' + this.settings.ID_CUSPS, this.paper._paperElementId)
     const numbersRadius = this.radius + ((this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO - this.rulerRadius) / 2)
@@ -187,11 +186,16 @@ class Transit {
     // Cusps
     for (let i = 0, ln = cusps.length; i < ln; i++) {
       // Lines
-      const startPosition = bottomPosition = getPointPosition(this.cx, this.cy, this.radius, cusps[i] + this.shift, this.settings)
+      const startPosition = getPointPosition(this.cx, this.cy, this.radius, cusps[i] + this.shift, this.settings)
       const endPosition = getPointPosition(this.cx, this.cy, this.radius + this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO - this.rulerRadius, cusps[i] + this.shift, this.settings)
       const line = this.paper.line(startPosition.x, startPosition.y, endPosition.x, endPosition.y)
       line.setAttribute('stroke', this.settings.LINE_COLOR)
-      line.setAttribute('stroke-width', (this.settings.CUSPS_STROKE * this.settings.SYMBOL_SCALE).toString())
+
+      if (mainAxis.includes(i)) {
+        line.setAttribute('stroke-width', (this.settings.SYMBOL_AXIS_STROKE * this.settings.SYMBOL_SCALE).toString())
+      } else {
+        line.setAttribute('stroke-width', (this.settings.CUSPS_STROKE * this.settings.SYMBOL_SCALE).toString())
+      }
 
       wrapper.appendChild(line)
 


### PR DESCRIPTION
Closes #17

**Status:** SHIP (iteration 1)

## Summary

- Fixed the transit `drawCusps` method in `project/src/transit.ts` to differentiate main axis cusp lines (AS, IC, DC, MC) from other cusps using `SYMBOL_AXIS_STROKE` instead of the default `CUSPS_STROKE`, matching the existing behavior in `radix.ts`.
- Added a `mainAxis.includes(i)` conditional check around the `stroke-width` attribute assignment.
- Removed the unused `bottomPosition` variable declaration and its assignment in the loop.
- All 425 tests pass, build succeeds with no errors.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_