### PR TITLE
fix: remove unused variables in radix.ts, transit.ts, and zodiac.ts

### DIFF
--- a/project/src/radix.ts
+++ b/project/src/radix.ts
@@ -142,9 +142,6 @@ class Radix {
     const universe = this.universe
     const wrapper = getEmptyWrapper(universe, this.paper.root.id + '-' + this.settings.ID_RADIX + '-' + this.settings.ID_POINTS, this.paper.root.id)
 
-    const gap = this.radius - (this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO + this.radius / this.settings.INDOOR_CIRCLE_RADIUS_RATIO)
-    const step = (gap - 2 * (this.settings.PADDING * this.settings.SYMBOL_SCALE)) / Object.keys(this.data.planets).length
-
     const pointerRadius = this.radius - (this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO + this.rulerRadius)
     let startPosition
     let endPosition

--- a/project/src/transit.ts
+++ b/project/src/transit.ts
@@ -88,9 +88,6 @@ class Transit {
     const universe = this.universe
     const wrapper = getEmptyWrapper(universe, this.paper._paperElementId + '-' + this.settings.ID_TRANSIT + '-' + this.settings.ID_POINTS, this.paper._paperElementId)
 
-    const gap = this.radius - (this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO + this.radius / this.settings.INDOOR_CIRCLE_RADIUS_RATIO)
-    const step = (gap - 2 * (this.settings.PADDING * this.settings.SYMBOL_SCALE)) / Object.keys(planets).length
-
     const pointerRadius = this.radius + (this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO)
     let startPosition
     let endPosition
@@ -173,7 +170,6 @@ class Transit {
       return
     }
 
-    let bottomPosition
     const universe = this.universe
     const wrapper = getEmptyWrapper(universe, this.paper._paperElementId + '-' + this.settings.ID_TRANSIT + '-' + this.settings.ID_CUSPS, this.paper._paperElementId)
     const numbersRadius = this.radius + ((this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO - this.rulerRadius) / 2)
@@ -187,7 +183,7 @@ class Transit {
     // Cusps
     for (let i = 0, ln = cusps.length; i < ln; i++) {
       // Lines
-      const startPosition = bottomPosition = getPointPosition(this.cx, this.cy, this.radius, cusps[i] + this.shift, this.settings)
+      const startPosition = getPointPosition(this.cx, this.cy, this.radius, cusps[i] + this.shift, this.settings)
       const endPosition = getPointPosition(this.cx, this.cy, this.radius + this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO - this.rulerRadius, cusps[i] + this.shift, this.settings)
       const line = this.paper.line(startPosition.x, startPosition.y, endPosition.x, endPosition.y)
       line.setAttribute('stroke', this.settings.LINE_COLOR)

--- a/project/src/zodiac.ts
+++ b/project/src/zodiac.ts
@@ -282,7 +282,7 @@ class Zodiac {
     if (exactExaltation != null && Array.isArray(exactExaltation)) {
       for (let i = 0, ln = exactExaltation.length; i < ln; i++) {
         if (planet.name === exactExaltation[i].name) {
-          if (this.hasConjunction(planet.position, exactExaltation[i].position, exactExaltation[i].orbit)) {
+          if (this.hasConjunction(position, exactExaltation[i].position, exactExaltation[i].orbit)) {
             result.push(this.settings.DIGNITIES_EXACT_EXALTATION)
           }
         }


### PR DESCRIPTION
Closes #18

## Status
✅ SHIP — Iteration 1

## Summary
- Removed unused `gap` and `step` variables from `radix.ts` `drawPoints()` and `transit.ts` `drawPoints()`
- Removed unused `bottomPosition` variable from `transit.ts` `drawCusps()`
- Fixed `zodiac.ts` `getDignities()`: the normalized `position` variable was computed but never used — changed `hasConjunction` call to use normalized `position` instead of raw `planet.position`, fixing a latent bug for positions exceeding 360°
- Skipped `mainAxis` in `transit.ts` as it is tracked separately in #17
- All 425 tests pass; ESLint reduced to 1 warning (the #17-tracked `mainAxis`)

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_