### PR TITLE
fix: correct wrapping formula and tautological condition in hasConjunction

### DIFF
--- a/project/src/zodiac.ts
+++ b/project/src/zodiac.ts
@@ -320,7 +320,7 @@ class Zodiac {
     let result = false
 
     const minOrbit = (pointPosition - orbit / 2) < 0
-      ? radiansToDegree(2 * Math.PI) - (pointPosition - orbit / 2)
+      ? radiansToDegree(2 * Math.PI) + (pointPosition - orbit / 2)
       : pointPosition - orbit / 2
 
     const maxOrbit = (pointPosition + orbit / 2) >= radiansToDegree(2 * Math.PI)
@@ -328,7 +328,7 @@ class Zodiac {
       : (pointPosition + orbit / 2)
 
     if (minOrbit > maxOrbit) { // crossing over zero
-      if (minOrbit >= planetPosition && planetPosition <= minOrbit) {
+      if (planetPosition >= minOrbit || planetPosition <= maxOrbit) {
         result = true
       }
     } else {


### PR DESCRIPTION
Closes #24

## Summary

- **Bug 1:** Fixed incorrect wrapping formula in `hasConjunction()` — changed `radiansToDegree(2 * Math.PI) - (pointPosition - orbit / 2)` to `radiansToDegree(2 * Math.PI) + (pointPosition - orbit / 2)` so negative angles wrap correctly to `360 - N` instead of producing invalid values > 360°.
- **Bug 2:** Replaced tautological condition `minOrbit >= planetPosition && planetPosition <= minOrbit` with `planetPosition >= minOrbit || planetPosition <= maxOrbit` to properly detect planets within a zero-crossing orbit range.

## Status

✅ SHIP — Iteration 1

All 425 tests pass. Lint: 0 errors. Build: successful.

## Test plan

- [x] All existing tests pass (425/425)
- [x] Lint passes with 0 errors
- [x] Build compiles successfully

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_