### PR TITLE
fix: add main axis stroke differentiation to transit drawCusps()

### DIFF
--- a/project/src/transit.ts
+++ b/project/src/transit.ts
@@ -191,7 +191,12 @@ class Transit {
       const endPosition = getPointPosition(this.cx, this.cy, this.radius + this.radius / this.settings.INNER_CIRCLE_RADIUS_RATIO - this.rulerRadius, cusps[i] + this.shift, this.settings)
       const line = this.paper.line(startPosition.x, startPosition.y, endPosition.x, endPosition.y)
       line.setAttribute('stroke', this.settings.LINE_COLOR)
-      line.setAttribute('stroke-width', (this.settings.CUSPS_STROKE * this.settings.SYMBOL_SCALE).toString())
+
+      if (mainAxis.includes(i)) {
+        line.setAttribute('stroke-width', (this.settings.SYMBOL_AXIS_STROKE * this.settings.SYMBOL_SCALE).toString())
+      } else {
+        line.setAttribute('stroke-width', (this.settings.CUSPS_STROKE * this.settings.SYMBOL_SCALE).toString())
+      }
 
       wrapper.appendChild(line)
 


### PR DESCRIPTION
Closes #25

**Status:** SHIP (iteration 1)

## Summary

- Added conditional stroke-width logic to `transit.ts` `drawCusps()` so main axis cusps (AS/IC/DC/MC) use `SYMBOL_AXIS_STROKE` while regular cusps use `CUSPS_STROKE`, matching the existing `radix.ts` behavior.
- All 425 tests pass, linter reports 0 errors.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_