### PR TITLE
fix: use normalized position in getDignities exact exaltation check

### DIFF
--- a/project/src/zodiac.extended.test.ts
+++ b/project/src/zodiac.extended.test.ts
@@ -171,6 +171,16 @@ describe('Zodiac - extended', () => {
       expect(result).not.toContain(default_settings.DIGNITIES_EXACT_EXALTATION)
     })
 
+    test('should detect exact exaltation for position >= 360 (normalized)', () => {
+      // 379 mod 360 = 19, which should match exact exaltation at 19
+      const result = zodiac.getDignities(
+        { name: 'Sun', position: 379 },
+        [{ name: 'Sun', position: 19, orbit: 2 }]
+      )
+      expect(result).toContain(default_settings.DIGNITIES_EXALTATION)
+      expect(result).toContain(default_settings.DIGNITIES_EXACT_EXALTATION)
+    })
+
     test('should handle exact exaltation with empty array', () => {
       const result = zodiac.getDignities({ name: 'Sun', position: 19 }, [])
       expect(result).toContain(default_settings.DIGNITIES_EXALTATION)

--- a/project/src/zodiac.ts
+++ b/project/src/zodiac.ts
@@ -282,7 +282,7 @@ class Zodiac {
     if (exactExaltation != null && Array.isArray(exactExaltation)) {
       for (let i = 0, ln = exactExaltation.length; i < ln; i++) {
         if (planet.name === exactExaltation[i].name) {
-          if (this.hasConjunction(planet.position, exactExaltation[i].position, exactExaltation[i].orbit)) {
+          if (this.hasConjunction(position, exactExaltation[i].position, exactExaltation[i].orbit)) {
             result.push(this.settings.DIGNITIES_EXACT_EXALTATION)
           }
         }


### PR DESCRIPTION
Closes #26

## Status
**SHIP** - Iteration 1

## Summary
- Fixed bug in `getDignities()` where the normalized `position` variable was computed but never used in the exact exaltation conjunction check
- Changed `hasConjunction()` call at line 285 in `zodiac.ts` to use the normalized `position` instead of raw `planet.position`, ensuring correct results for planet positions >= 360°
- Added regression test verifying exact exaltation detection works for positions >= 360° (e.g., 379° normalizes to 19°)
- All 426 tests pass, no lint errors introduced

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_